### PR TITLE
[Bug#47981] Latest notification can't mark as read

### DIFF
--- a/app/Helpers/Helpers.php
+++ b/app/Helpers/Helpers.php
@@ -81,6 +81,11 @@ class Helpers
         return $notification->markAsRead();
     }
 
+    public static function getLatestNotification()
+    {
+        return auth()->user()->Notifications->first();
+    }
+
     public static function getFileFromExcel($path)
     {
         $pathParts = pathinfo($path);

--- a/app/Http/Controllers/Admin/NotificationController.php
+++ b/app/Http/Controllers/Admin/NotificationController.php
@@ -37,4 +37,11 @@ class NotificationController extends Controller
 
         return response()->json(['markAsReadAll' => true]);
     }
+
+    public function getLatestNotification()
+    {
+        $notification = Helpers::getLatestNotification();
+
+        return response()->json(compact('notification'));
+    }
 }

--- a/resources/js/admin/notification.js
+++ b/resources/js/admin/notification.js
@@ -7,7 +7,7 @@ $(document).ready(function () {
         cluster: "ap2",
     });
     var channel = pusher.subscribe("NotificationEvent");
-    channel.bind("send-notification", function (data) {
+    channel.bind("send-notification", async function (data) {
         let pending = parseInt($("#notifications").find(".pending").html());
         if (Number.isNaN(pending)) {
             $("#notifications").append(
@@ -18,8 +18,10 @@ $(document).ready(function () {
                 .find(".pending")
                 .html(pending + 1);
         }
+        let response = await axios.get('/admin/notify/get-latest-noti');
         let notificationItem = `
-        <li class="notification-item unread">
+        <li class="notification-item unread"
+            data-id="${response.data.notification.id}">
             <p>${trans.__("notification_mess", { email: data.email })}</p>
             <p class="float-right">${trans.__("recent")}</p>
         </li>`;

--- a/routes/web.php
+++ b/routes/web.php
@@ -79,6 +79,7 @@ Route::prefix('admin')->name('admin.')->middleware(['auth', 'auth.admin', 'verif
 
     Route::put('/notify/mark-as-read', [NotificationController::class, 'markAsRead']);
     Route::put('/notify/mark-as-read-all', [NotificationController::class, 'markAsReadAll']);
+    Route::get('/notify/get-latest-noti', [NotificationController::class, 'getLatestNotification']);
 });
 
 Route::middleware(['auth'])->prefix('api')->name('api.')->group(function () {

--- a/tests/Unit/Http/Controllers/Admin/NotificationControllerTest.php
+++ b/tests/Unit/Http/Controllers/Admin/NotificationControllerTest.php
@@ -104,4 +104,18 @@ class NotificationControllerTest extends TestCase
         $this->assertEquals(500, $response->getStatusCode());
         $this->assertArrayHasKey('error', (array) json_decode($response->getContent()));
     }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+    */
+    public function testGetLatestNotificationMethod()
+    {
+        $this->helpers->shouldReceive('getLatestNotification')->andReturn($this->notification);
+
+        $response = $this->controller->getLatestNotification();
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertArrayHasKey('notification', (array) json_decode($response->getContent()));
+    }
 }


### PR DESCRIPTION
## Related Tickets:
- [#47981](https://edu-redmine.sun-asterisk.vn/issues/47981)

## WHAT this PR does?
- Fix bug Notification mới không thể mark as read do thiếu notification id

## Notes Impacted Areas:
- N/A.

## Attachments:
- N/A.
